### PR TITLE
style.css: Add style for arrow move button

### DIFF
--- a/coala.css
+++ b/coala.css
@@ -663,6 +663,21 @@ a.chip i {
   cursor: pointer;
 }
 
+.arrow-move-right, .arrow-move-left {
+  display: inline;
+  position: fixed;
+  bottom: 40px;
+  z-index: 9999;
+}
+
+.arrow-move-right {
+  right: 20%;
+}
+
+.arrow-move-left {
+  left: 20%;
+}
+
 .theatre .description a {
   color: azure;
 }


### PR DESCRIPTION
To fix overlaping invisible block element
that causing link behind it unclickable.

Fixes https://github.com/coala/projects/issues/273