### PR TITLE
coala.css: Make textarea unresizable along horizontal

### DIFF
--- a/coala.css
+++ b/coala.css
@@ -158,6 +158,7 @@ pre.card,
 
 textarea.pre {
   height: 7rem;
+  resize: vertical;
 }
 
 .card pre {


### PR DESCRIPTION
Resize property is disabled by adding `resize: vertical` to `textarea.pre`. This line ensures that textarea will only be vertically resizable by hand.

Fixes https://github.com/coala/landing-frontend/issues/190