### PR TITLE
style.css: add horizontal scroll to container

### DIFF
--- a/coala.css
+++ b/coala.css
@@ -780,6 +780,7 @@ a.chip i {
   padding: 1em;
   color: white;
   font-family: "Roboto Mono";
+  overflow-x: auto;
 }
 
 .coala-online .results-data {


### PR DESCRIPTION
The `overflow-x: auto` property in `.coafile, .coala-online` selector
ensures horizontal scrolling when there are lot of bears.

Fixes https://github.com/coala/landing-frontend/issues/189