### PR TITLE
Pin theatre view to bottom to prevent clipping

### DIFF
--- a/coala.css
+++ b/coala.css
@@ -543,6 +543,7 @@ a.chip i {
   opacity: 1;
   transform: scaleX(1);
   top: 10%;
+  bottom: 0;
 }
 
 .theatre.modal.margin {
@@ -559,6 +560,10 @@ a.chip i {
   max-width: none;
   padding-left: 1vw;
   padding-right: 1vw;
+}
+
+.theatre .profile {
+  padding-bottom: 1vw;
 }
 
 .theatre .dashboard {


### PR DESCRIPTION
`.theatre.modal` has `top: 10%` so the content is clipped 10% from the
bottom. This adds `bottom: 0` to prevent that from happening.

Also add padding-bottom to `.theatre.profile` so it looks nicer.

Fixes https://github.com/coala/coalaCSS/issues/26

Result:
![image](https://user-images.githubusercontent.com/1438859/32724229-ff41487c-c8a2-11e7-89bb-cf623066f7b1.png)
