### PR TITLE
coala.css: Add chip width

### DIFF
--- a/coala.css
+++ b/coala.css
@@ -365,6 +365,10 @@ main {
 
 /* Chips */
 
+a.chip {
+  width: max-content;
+}
+
 a.chip i {
   float: left;
   margin: 0 8px 0 -12px;


### PR DESCRIPTION
this addition of width ensures that-
links below title are proper in mobile view.
Assigning value max-content display links in all screen sizes.

Fixes https://github.com/coala/landing-frontend/issues/85